### PR TITLE
feature/issue4_SlackAPI学習用Pythonスクリプトの作成

### DIFF
--- a/app/slackapi/slack_presence_status.py
+++ b/app/slackapi/slack_presence_status.py
@@ -1,9 +1,12 @@
 import os
 import requests
 
+class MissingEnvironmentVariableError(RuntimeError):
+    """Raised when a required environment variable is missing."""
+
 SLACK_TOKEN = os.environ.get("SLACK_USER_TOKEN")
 if not SLACK_TOKEN:
-    raise Exception("SLACK_USER_TOKEN 環境変数が設定されていません")
+    raise MissingEnvironmentVariableError("SLACK_USER_TOKEN 環境変数が設定されていません")
 
 
 def set_presence_away():

--- a/app/slackapi/slack_presence_status.py
+++ b/app/slackapi/slack_presence_status.py
@@ -23,7 +23,10 @@ def set_presence_away():
     }
     data = {"presence": "away"}
     response = requests.post(url, headers=headers, json=data)
-    print("setPresence:", response.json())
+    if response.ok and response.json().get("ok"):
+        print("setPresence succeeded:", response.json())
+    else:
+        raise Exception(f"Failed to set presence: {response.json()}")
 
 
 def set_custom_status():

--- a/app/slackapi/slack_presence_status.py
+++ b/app/slackapi/slack_presence_status.py
@@ -1,0 +1,56 @@
+import os
+import requests
+
+SLACK_TOKEN = os.environ.get("SLACK_USER_TOKEN")
+if not SLACK_TOKEN:
+    raise Exception("SLACK_USER_TOKEN 環境変数が設定されていません")
+
+
+def set_presence_away():
+    """
+    Slackのユーザーのプレゼンスを「離席中（away）」に設定します。
+
+    Slack APIの `users.setPresence` エンドポイントを利用して、
+    認証済みユーザーのプレゼンスを「away」に変更します。
+    """
+    url = "https://slack.com/api/users.setPresence"
+    headers = {
+        "Authorization": f"Bearer {SLACK_TOKEN}",
+        "Content-Type": "application/json"
+    }
+    data = {"presence": "away"}
+    response = requests.post(url, headers=headers, json=data)
+    print("setPresence:", response.json())
+
+
+def set_custom_status():
+    """
+    Slackのユーザーステータスをカスタムメッセージ「離席中です」と
+    絵文字「:coffee:」に設定します。
+
+    Slack APIの `users.profile.set` エンドポイントを利用して、
+    認証済みユーザーのプロフィールステータスを更新します。
+    """
+    url = "https://slack.com/api/users.profile.set"
+    headers = {
+        "Authorization": f"Bearer {SLACK_TOKEN}",
+        "Content-Type": "application/json"
+    }
+    data = {
+        "profile": {
+            "status_text": "離席中です",
+            "status_emoji": ":coffee:",
+            "status_expiration": 0
+        }
+    }
+    response = requests.post(url, headers=headers, json=data)
+    print("profile.set:", response.json())
+
+
+if __name__ == "__main__":
+    """
+    スクリプトを直接実行した場合、Slackのプレゼンスを「away」にし、
+    ステータスを「離席中です :coffee:」に設定します。
+    """
+    set_presence_away()
+    set_custom_status()

--- a/docs/infra/prod-python.md
+++ b/docs/infra/prod-python.md
@@ -60,6 +60,7 @@ sudo -u agile_pmbok /bin/bash << 'EOF'
 cd /opt/Agile-PMBOK-Ops
 source venv/bin/activate
 pip install -r requirements.txt
+pip install --upgrade pip
 deactivate
 EOF
 ```

--- a/docs/infra/prod-python.md
+++ b/docs/infra/prod-python.md
@@ -1,0 +1,71 @@
+# 本番環境Python実行環境整備
+
+さくらインターネットのVPNサーバーに、Python3の実行環境を整備する手順を解説します。
+
+## ■ pip環境の整備
+
+### 1. root（または sudo 権限）で pip をインストールする
+
+まずはホスト側（root または sudo 権限のあるユーザー）で以下を実行してください。Debian/Ubuntu 系であれば、python3-pip をインストールすると Python3 用の pip コマンドが使えるようになります。
+
+```sh
+# pipが使えるか確認
+which pip3
+sudo apt update
+sudo apt install -y python3-pip
+sudo apt install -y python3.12-venv
+```
+
+これで、システム全体に pip3（および /usr/bin/pip3） がインストールされます。
+
+### 2. agile_pmbok ユーザーで pip3 を使う
+
+パッケージがインストールできたら、再度 agile_pmbok ユーザーのシェルを開き、pip3 が使えるか確認します。
+
+```sh
+sudo -u agile_pmbok /bin/bash
+which pip3
+# → /usr/bin/pip3 などが返ってくるはずです
+pip3 --version
+# → pip のバージョンが返ってくれば OK
+```
+
+もし pip3 で問題なくバージョンが表示されれば、requirements.txt を指定してインストールが可能です。
+
+```sh
+cd /opt/Agile-PMBOK-Ops
+pip3 install -r requirements.txt
+```
+
+※ もし “コマンドが見つかりません” と出る場合は、システム側でのインストールが正しく行われていない可能性があります。再度 sudo apt install python3-pip を実行してください。
+
+## ■ python仮想環境の整備
+
+### 1. プロジェクト直下に仮想環境（venv）を作ってインストールする
+
+/opt/Agile-PMBOK-Ops 下に venv フォルダを作り、その中に Python 仮想環境を構築します。
+（この例では /opt/Agile-PMBOK-Ops/venv に作成）
+
+```sh
+# agile_pmbok ユーザー権限で仮想環境を作成
+sudo -u agile_pmbok python3 -m venv /opt/Agile-PMBOK-Ops/venv
+```
+
+* もし /opt/Agile-PMBOK-Ops の下に書き込み権限がない場合は、先にオーナーを変えるか（例：sudo chown -R agile_pmbok:agile_pmbok_ops /opt/Agile-PMBOK-Ops）、root で venv を作成し、その後オーナーを agile_pmbok に変更してください。
+
+### 2.	仮想環境をアクティベートして依存をインストールする
+
+```sh
+sudo -u agile_pmbok /bin/bash << 'EOF'
+cd /opt/Agile-PMBOK-Ops
+source venv/bin/activate
+pip install -r requirements.txt
+deactivate
+EOF
+```
+
+### 3.	スクリプトを venv の Python で実行する
+
+```sh
+sudo -u agile_pmbok /opt/Agile-PMBOK-Ops/venv/bin/python /opt/Agile-PMBOK-Ops/app/slackapi/slack_presence_status.py
+```

--- a/docs/infra/prod-python.md
+++ b/docs/infra/prod-python.md
@@ -13,7 +13,7 @@
 which pip3
 sudo apt update
 sudo apt install -y python3-pip
-sudo apt install -y python3.12-venv
+sudo apt install -y python3-venv
 ```
 
 これで、システム全体に pip3（および /usr/bin/pip3） がインストールされます。


### PR DESCRIPTION
このプルリクエストでは、主に2つの変更点が導入されています。Slack のプレゼンスとステータスの更新を管理するための Python スクリプトの追加と、本番環境で Python ランタイム環境を設定するためのドキュメントの更新です。これらの変更は、Slack API 統合の強化と Python 環境設定の効率化を目的としています。

### Slack API 統合:
* **`set_presence_away` および `set_custom_status` 関数を追加**: これらの関数は Slack API を利用して、ユーザーのプレゼンスを「離席中」に更新し、メッセージと絵文字を含むカスタムステータスを設定します。 (`app/slackapi/slack_presence_status.py`、[app/slackapi/slack_presence_status.pyR1-R56](diffhunk://#diff-a25122c7749205a98c4487eab7dc4c4f5d641747445f5280bfa98d4ed3ba25e7R1-R56))
* **環境変数の検証**: スクリプト実行前に`SLACK_USER_TOKEN`環境変数が設定されていることを確認します。設定されていない場合は例外が発生します。 (`app/slackapi/slack_presence_status.py`, [app/slackapi/slack_presence_status.pyR1-R56](diffhunk://#diff-a25122c7749205a98c4487eab7dc4c4f5d641747445f5280bfa98d4ed3ba25e7R1-R56))

### 本番環境向け Python 環境のセットアップ:
* **Python と `pip` の詳細なセットアップ手順**: `pip` のインストールと Python 環境の設定 (依存関係を分離するための仮想環境 (`venv`) を含む) について、ステップバイステップで説明します。 (`docs/infra/prod-python.md`、[docs/infra/prod-python.mdR1-R71](diffhunk://#diff-79bfcea4335f894ae3a5983c0a0189ed3e92e176dc7e40892a249571856ca268R1-R71))
* **仮想環境の使用例**: 仮想環境をアクティブ化し、依存関係をインストールし、構成された Python ランタイムを使用してスクリプトを実行する方法を示します。 (`docs/infra/prod-python.md`、[docs/infra/prod-python.mdR1-R71](diffhunk://#diff-79bfcea4335f894ae3a5983c0a0189ed3e92e176dc7e40892a249571856ca268R1-R71))